### PR TITLE
change the primary color to be slightly lighter on dark theme

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -19,7 +19,7 @@
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme='dark'] {
-  --ifm-color-primary: #B50F1B;
+  --ifm-color-primary: #FF2434;
   --ifm-color-primary-dark: #94000B;
   --ifm-color-primary-darker: #6B0008;
   --ifm-color-primary-darkest: #240003;


### PR DESCRIPTION
This PR changes our primary accent color to be slightly lighter on the dark theme to maintain [AA WCAG compliance](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Guides/Understanding_WCAG/Perceivable/Color_contrast), as this is a color used in text elements.

## Technical details / Media

Before (Ratio: 2.50):

<img width="287" height="268" alt="image" src="https://github.com/user-attachments/assets/2523d775-0ea1-47c5-a3c4-8e55e360412e" />

<img width="305" height="295" alt="image" src="https://github.com/user-attachments/assets/05baa361-c024-47e4-b71b-e3238ee6fafd" />

After (Ratio: 4.55):

<img width="299" height="307" alt="image" src="https://github.com/user-attachments/assets/42e3c9bf-5a0d-476b-aa6c-3ab33fc737fa" />

<img width="277" height="264" alt="image" src="https://github.com/user-attachments/assets/bf7a9495-ba31-4cc1-ad04-f411ad0bc237" />
